### PR TITLE
fix broken Architecture links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # SnapRoute Layer 3 Protocol Stack
 
-http://www.snaproute.com 
+http://www.snaproute.com
 
 
 
-Complete product documentation is available at 
+Complete product documentation is available at
 [Product Overview] (http://opensnaproute.github.io/docs/)
 
-Complete system architecture can be found 
-[Here](http://opensnaproute.github.io/docs/architecture.html) 
+Complete system architecture can be found
+[Here](http://opensnaproute.github.io/docs/architecture.html)
 
 
-![alt text](https://github.com/SnapRoute/l3/blob/master/docs/L3_Module_Diagram.png "Architecture")
+![L3 Architecture](docs/L3_Module_Diagram.png "L3 Architecture")
 
 ## Synopsis
 This repository holds source code and tests for various the layer 3 protocols and the infrastructure code for layer 3 protocols provided by SnapRoute.
 Currently it has following protocols and infrastructure modules:
- - [Address Resolution Protocol] (https://github.com/SnapRoute/l3/blob/master/arp/README.md "arp README")
- - [Bi-directional Forwarding Detection] (https://github.com/SnapRoute/l3/tree/master/bfd "BFD README")
- - [Border Gateway Protocol] (https://github.com/SnapRoute/l3/tree/master/bgp "BGP README")
- - [Dynamic Host Configuration Protocol Relay] (https://github.com/SnapRoute/l3/tree/master/dhcp_relay "Dhcp Relay Agent README")
- - [Dynamic Host Configuration Protocol] (https://github.com/SnapRoute/l3/tree/master/dhcp "Dhcp Agent README")
- - [Open Shortest Path First] (https://github.com/SnapRoute/l3/tree/master/ospf "OSPF README")
- - [Routing Information Base] (https://github.com/SnapRoute/l3/tree/master/rib "RIB Daemon README")
- - Tunneling Protocols
- - [Virtual Router Redundancy Protocol](https://github.com/SnapRoute/l3/tree/master/vrrp "VRRP's README")
+ - [Address Resolution Protocol](arp/ "ARP")
+ - [Bi-directional Forwarding Detection](bfd/ "BFD")
+ - [Border Gateway Protocol](bgp/ "BGP")
+ - [Dynamic Host Configuration Protocol Relay](dhcp_relay/ "DHCP Relay Agent")
+ - [Dynamic Host Configuration Protocol](dhcp/ "DHCP Agent")
+ - [Open Shortest Path First](ospf/ "OSPF")
+ - [Routing Information Base](rib/ "RIB Daemon")
+ - [Tunneling Protocols](tunnel/ "Tunneling")
+ - [Virtual Router Redundancy Protocol](vrrp/ "VRRP")

--- a/arp/README.md
+++ b/arp/README.md
@@ -5,7 +5,7 @@ The address resolution protocol (arp) is a protocol used by the Internet Protoco
 
 
 ### Architecture
-![alt text](https://github.com/SnapRoute/l3/blob/master/arp/docs/ARP.png "Architecture")
+![ARP Architecture](docs/ARP.png "ARP Architecture")
 
 ### Description
 
@@ -28,15 +28,15 @@ Configutation Object Name: **ArpGlobal**
 
 
 >  - Update ARP Gloabl Config:
-	
+
 		bool UpdateArpGlobal(1: ArpGlobal origconfig, 2: ArpGlobal newconfig, 3: list<bool> attrset);
 
 
->  - Delete ARP Global Config: 
+>  - Delete ARP Global Config:
 
 		bool DeleteArpGlobal(1: ArpGlobal config);
 
-State Object Name: **ArpEntryState**, **ArpLinuxEntryState** 
+State Object Name: **ArpEntryState**, **ArpLinuxEntryState**
 
 >  - Get the list of ARP Entries (Object Name: ArpEntryState):
 

--- a/bgp/README.md
+++ b/bgp/README.md
@@ -14,7 +14,7 @@ The following RFCs have been implemented with plan to add more:
     6. https://tools.ietf.org/html/draft-ietf-idr-add-paths-14: Advertisement of Multiple Paths in BGP
 
 ### Architecture
-![alt text](https://github.com/SnapRoute/l3/blob/master/bgp/docs/BGP_Module.png "Architecture")
+![BGP Architecture](docs/BGP_Module.png "BGP Architecture")
 
 ### Interfaces
 Exposed Interfaces

--- a/dhcp/README.md
+++ b/dhcp/README.md
@@ -5,7 +5,7 @@ Dynamic Host Configuration Protocol (DHCP) is a client/server protocol that auto
 
 
 ### Architecture
-![alt text](https://github.com/SnapRoute/l3/blob/master/dhcp/docs/DHCP.png "Architecture")
+![DHCP Architecture](docs/DHCP.png "DHCP Architecture")
 
 ### Interfaces
 Configuration Object Name: **DhcpGlobalConfig**

--- a/dhcp_relay/README.md
+++ b/dhcp_relay/README.md
@@ -7,7 +7,7 @@ current dependencies with a configuration daemon CONFD and programability of HW 
 The Relay Agent will have an instance running per interface.
 
 ### Architecture
-![alt_text] (docs/Dhcp_Relay_Agent.png)
+![DHCP Relay Agent Architecture](docs/Dhcp_Relay_Agent.png "DHCP Relay Agent Architecture")
 
 ### Interfaces
 Dhcp Relay Agent is a standalone protocol daemon with configuration dependant to configuration daemon CONFD
@@ -20,7 +20,7 @@ Dhcp Relay Agent is a standalone protocol daemon with configuration dependant to
     3. Vlan Create/Delete from ASICD via Nano-Msg
 #####Packet Rx/Tx
     1. Server -> Relay Agent -> Client, we will use GoPacket
-    2. Client -> Relay Agent -> Server, we will write to UDP directly using golang net interface package 
+    2. Client -> Relay Agent -> Server, we will write to UDP directly using golang net interface package
 
 #####Dhcp Relay has following state:
   1. Receive DISCOVER Packet

--- a/ospf/README.md
+++ b/ospf/README.md
@@ -2,40 +2,41 @@
 
 ### Introduction
 This module implements Open Shortest Path First.v2
-RFC 2328 
+RFC 2328
 
 ### Architecture
-![alt text](https://github.com/SnapRoute/l3/blob/master/ospf/docs/ospf_architecture.png "Architecture")
+![OSPF Architecture](docs/ospf_architecture.png "OSPF Architecture")
+
 ### Modules
 OSPF has below components
-1) Interface FSM - 
+1) Interface FSM -
 Handles per interfce OSPF config events,send hello packets, DR/BDR election .
- It signals Neighbor FSM whenenever new neighbor is detected. 
+ It signals Neighbor FSM whenenever new neighbor is detected.
 
 2) Neighbor FSM -
-This component implements 
+This component implements
 RX packets such as DB description , LSA Update/Request/Ack.
-Takes care of flooding. 
+Takes care of flooding.
 Inform LSDB for different events such as neighbor full, install LSA.
 
 3) LSDB -
 LSA database. Stores 5 types of LSAs.
-Trigger SPF when new LSA is installed . 
+Trigger SPF when new LSA is installed .
 Generate router/networks LSAs for neighbor full event.
 Generate summary LSA if ABR.
 Generate AS external if ASBR.
 Implements LSA ageing.
 Inform Neighbor FSM for flooding  when new LSA is installed.
 
-4)SPF - 
+4)SPF -
 Takes care of shortest path calculation and install routes.
 Signal LSDB to generate summary LSA when ABR.
 
 5) RIBd listener -
-Listens to RIBd updates when OSPF policy is configured. 
-When router is acting as ASBR - RIbd listener will receive route updates as per the 
+Listens to RIBd updates when OSPF policy is configured.
+When router is acting as ASBR - RIbd listener will receive route updates as per the
 policy statement.
 It signals LSDB for AS external generation when router is configured as ASBR.
 
 ### Configuration
-Current OSPF configuration is as per OSPF-MIB.yang file 
+Current OSPF configuration is as per OSPF-MIB.yang file

--- a/rib/README.md
+++ b/rib/README.md
@@ -11,13 +11,13 @@ Summary of functionality implemented by this module is as follows:
    b. policy statements create/delete/updates
    c. policy definitions create/delete/updates
 
-3. Implement policy engine 
-   a. Based on the policy objects configured and applied on the device, the policy engine filter will match on the conditions provisioned and implement actions based on the application location. 
+3. Implement policy engine
+   a. Based on the policy objects configured and applied on the device, the policy engine filter will match on the conditions provisioned and implement actions based on the application location.
 For instance, the policy engine filter may result in redistributing certain (route type based/ network prefix based) routes into other applications (BGP,OSPF, etc.,)
 4. Responsible for calling ASICd thrift APIs to program the routes in the FIB.
 
 ### Architecture
-![alt text](https://github.com/SnapRoute/l3/blob/master/rib/docs/RIB_Daemon_Architecture.png "Architecture")
+![RIB Architecture](docs/RIB_Daemon_Architecture.png "RIB Architecture")
 
 ### Interfaces
 Exposed Interfaces


### PR DESCRIPTION
The links to Architecture images in the main README and in each
module's README were pointing to a non-existent repository, they
have been changed to relative links. The alt text of each image
has been updated also to improve accessibility.