### PR TITLE
Fix of build issue on PortConfigMtuChgNotigyMsg.

### DIFF
--- a/ospf/server/ospfAsicd.go
+++ b/ospf/server/ospfAsicd.go
@@ -85,7 +85,7 @@ func (server *OSPFServer) processAsicdNotification(asicdrxBuf []byte) {
 		return
 	}
 	if msg.MsgType == asicdCommonDefs.NOTIFY_PORT_CONFIG_MTU_CHANGE {
-		var mtuChangeMsg asicdCommonDefs.PortConfigMtuChgNotigyMsg
+		var mtuChangeMsg asicdCommonDefs.PortConfigMtuChgNotifyMsg
 		err = json.Unmarshal(msg.Msg, &mtuChangeMsg)
 		if err != nil {
 			server.logger.Err(fmt.Sprintln("Mtu change :Unable to unmarshal msg :", msg.Msg))


### PR DESCRIPTION
## DEPENDANT PULLS
NO

## Description
Build error corrected. Typo.

## Bug fixes for
No way to create bug for l3 project in github.

## Reviewer
Vitaliy Ivanov <vitaliyi@interfacemasters.com>

Typo corrected:
s/PortConfigMtuChgNotigyMsg/PortConfigMtuChgNotifyMsg/g

Build error description:
    make[2]: Entering directory `/home/vagrant/git/snaproute/src/l3/ospf'
    go build -o
    /home/vagrant/git/snaproute/src/flexswitch-vagrant_1.0.0.171.44//ospfd
    -ldflags="-r /opt/flexswitch/sharedlib" main.go
    # l3/ospf/server
    server/ospfAsicd.go:88: undefined:
    asicdCommonDefs.PortConfigMtuChgNotigyMsg
    make[2]: *** [exe] Error 2
    make[2]: Leaving directory `/home/vagrant/git/snaproute/src/l3/ospf'
    make[1]: *** [exe] Error 2
    make[1]: Leaving directory `/home/vagrant/git/snaproute/src/l3'
    make: *** [exe] Error 2

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>