### PR TITLE
Fix of build issue on layers.VxlanEthernet.

### DIFF
--- a/tunnel/vxlan/protocol/vtep.go
+++ b/tunnel/vxlan/protocol/vtep.go
@@ -379,11 +379,10 @@ func (vtep *VtepDbEntry) encapAndDispatchPkt(packet gopacket.Packet) {
                 if phandle != nil {
 
 		// outer ethernet header
-		eth := layers.VxlanEthernet{
-			layers.Ethernet{SrcMAC:       vtep.SrcMac,
+		eth := layers.Ethernet{
+			SrcMAC:       vtep.SrcMac,
 			DstMAC:       vtep.DstMac,
 			EthernetType: layers.EthernetTypeIPv4,
-			},
 		}
 		ip := layers.IPv4{
 			Version:    4,


### PR DESCRIPTION
## DEPENDANT PULLS
NO

## Bug fixes for
No way to open bug for l3 repo.

## Description

Layers package doesn't provide VxlanEthernet.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>